### PR TITLE
Enable chrome debugger support

### DIFF
--- a/tools/srcServer.js
+++ b/tools/srcServer.js
@@ -6,17 +6,21 @@ import open from 'open';
 
 /* eslint-disable no-console */
 
+
 const port = 3000;
 const app = express();
 const compiler = webpack(config);
+const { hot } = process.env;
+const hotMiddlewareEnabled = !hot || hot != 0;
 
 app.use(require('webpack-dev-middleware')(compiler, {
   noInfo: true,
   publicPath: config.output.publicPath
 }));
 
-app.use(require('webpack-hot-middleware')(compiler));
-
+if (hotMiddlewareEnabled) {
+  app.use(require('webpack-hot-middleware')(compiler));
+}
 app.get('*', function(req, res) {
   res.sendFile(path.join( __dirname, '../src/index.html'));
 });

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,9 +1,9 @@
 import webpack from 'webpack';
 import path from 'path';
-
+const { devtools } = process.env;
 export default {
   debug: true,
-  devtool: 'cheap-module-eval-source-map',
+  devtool:  devtools || 'cheap-module-eval-source-map',
   noInfo: false,
   entry: [
     'eventsource-polyfill', // necessary for hot reloading with IE


### PR DESCRIPTION
This is a patch that can help developers debug the application in chrome developer tools with breakpoints.
Description:
Up to now running the application was possible via "npm start"
Now It will **also be possible** to run it via "hot=0 devtools='source-map' npm start", and this way debugging will be enabled ( and hot replacement disabled )
